### PR TITLE
Remove PyYAML

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,6 @@ pytest-cov==2.5.1
 pytest-django==3.1.2
 python-dateutil==2.6.1
 pytz==2017.3
-PyYAML==3.12
 repoze.who==2.3
 requests==2.18.4
 requests-toolbelt==0.8.0


### PR DESCRIPTION
We received a vulnerability disclosure from GitHub indicating we need to upgrade. From what I see we don't seem to require this library anymore (requirements changed).