### PR TITLE
staging <- dev (#155)

### DIFF
--- a/talentmap_api/fsbid/services/bid_season.py
+++ b/talentmap_api/fsbid/services/bid_season.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 def get_bid_seasons(bsn_future_vacancy_ind, jwt_token):
     # set future vacancy indicator - default to 'Y'
     future_vacancy_ind = bsn_future_vacancy_ind if bsn_future_vacancy_ind else 'Y'
-    url = f"{API_ROOT}/bidSeasons?bsn_future_vacancy_ind={future_vacancy_ind}"
+    url = f"{API_ROOT}/bidSeasons?future_vacancy_ind={future_vacancy_ind}"
     bid_seasons = requests.get(url, headers={'JWTAuthorization': jwt_token, 'Content-Type': 'application/json'}, verify=False).json()  # nosec
     return map(fsbid_bid_season_to_talentmap_bid_season, bid_seasons)
 

--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -22,3 +22,7 @@ def get_pagination(query, count, base_url, host=None):
         "next": next_url,
         "previous": previous_url
     }
+
+def convert_multi_value(val):
+    if val is not None:
+        return val.split(',')

--- a/talentmap_api/fsbid/services/projected_vacancies.py
+++ b/talentmap_api/fsbid/services/projected_vacancies.py
@@ -15,12 +15,13 @@ API_ROOT = settings.FSBID_API_URL
 
 logger = logging.getLogger(__name__)
 
+
 def get_projected_vacancies(query, jwt_token, host=None):
     '''
     Gets projected vacancies from FSBid
     '''
     url = f"{API_ROOT}/futureVacancies?{convert_pv_query(query)}"
-    response = requests.get(url, headers={'JWTAuthorization': jwt_token, 'Content-Type': 'application/json'}, verify=False).json()  # nosec
+    response = requests.get(url, headers={'JWTAuthorization': jwt_token, 'Content-Type': 'application/json'}).json()
 
     projected_vacancies = map(fsbid_pv_to_talentmap_pv, response["Data"])
     return {
@@ -34,11 +35,13 @@ def get_projected_vacancies_count(query, jwt_token, host=None):
     Gets the total number of PVs for a filterset
     '''
     url = f"{API_ROOT}/futureVacanciesCount?{convert_pv_query(query)}"
-    response = requests.get(url, headers={'JWTAuthorization': jwt_token, 'Content-Type': 'application/json'}, verify=False).json()  # nosec
+    response = requests.get(url, headers={'JWTAuthorization': jwt_token, 'Content-Type': 'application/json'}).json()
     return {"count": response["Data"][0]["count(1)"]}
+
 
 # Pattern for extracting language parts from a string. Ex. "Spanish (3/3)"
 LANG_PATTERN = re.compile("(.*?)\(.*\)\s(\d)/(\d)")
+
 
 def parseLanguage(lang):
     '''
@@ -54,6 +57,7 @@ def parseLanguage(lang):
             language["spoken_proficiency"] = match.group(3)
             language["representation"] = match.group(0).rstrip()
             return language
+
 
 def fsbid_pv_to_talentmap_pv(pv):
     '''
@@ -126,23 +130,19 @@ def fsbid_pv_to_talentmap_pv(pv):
         }
     }
 
+
 def post_values(query):
     '''
     Handles mapping locations and groups of locations to FSBid expected params
     '''
     results = []
-    if query.get("is_domestic") == "true":
-        domestic_codes = Post.objects.filter(location__country__code="USA").values_list("_location_code", flat=True)
-        results = results + list(domestic_codes)
-    if query.get("is_domestic") == "false":
-        overseas_codes = Post.objects.exclude(location__country__code="USA").values_list("_location_code", flat=True)
-        results = results + list(overseas_codes)
     if query.get("position__post__in"):
         post_ids = query.get("position__post__in").split(",")
         location_codes = Post.objects.filter(id__in=post_ids).values_list("_location_code", flat=True)
         results = results + list(location_codes)
     if len(results) > 0:
-        return ",".join(results)
+        return results
+
 
 def bureau_values(query):
     '''
@@ -162,7 +162,25 @@ def bureau_values(query):
         reg_org_codes = Organization.objects.filter(Q(code__in=regional_bureaus) | Q(_parent_organization_code__in=regional_bureaus)).values_list("code", flat=True)
         results = results + list(reg_org_codes)
     if len(results) > 0:
-        return ",".join(results)
+        return results
+
+def overseas_values(query):
+    if query.get("is_domestic") == "true":
+        return "D"
+    if query.get("is_domestic") == "false":
+        return "O"
+
+sort_dict = {
+    "position__title": "pos_title_desc",
+    "position__grade": "pos_grade_code",
+    "position__bureau": "bureau_desc",
+    "ted": "ted",
+    "position__position_number": "position"
+}
+
+def sorting_values(sort):
+    if sort is not None:
+        return sort_dict.get(sort, None)
 
 def convert_pv_query(query):
     '''
@@ -171,19 +189,21 @@ def convert_pv_query(query):
     The TalentMap filters align with the position search filter naming
     '''
     values = {
+        "fv_request_params.order_by": sorting_values(query.get("ordering", None)),
         "fv_request_params.page_index": int(query.get("page", 1)),
         "fv_request_params.page_size": query.get("limit", 25),
         "fv_request_params.freeText": query.get("q", None),
-        "fv_request_params.bid_seasons": query.get("is_available_in_bidseason"),
+        "fv_request_params.bid_seasons": services.convert_multi_value(query.get("is_available_in_bidseason")),
         "fv_request_params.bureaus": bureau_values(query),
-        "fv_request_params.danger_pays": query.get("position__post__danger_pay__in"),
-        "fv_request_params.grades": query.get("position__grade__code__in"),
-        "fv_request_params.languages": query.get("language_codes"),
-        "fv_request_params.differential_pays": query.get("position__post__differential_rate__in"),
-        "fv_request_params.skills": query.get("position__skill__code__in"),
-        "fv_request_params.tod_codes": query.get("position__post__tour_of_duty__code__in"),
+        "fv_request_params.overseas_ind": overseas_values(query),
+        "fv_request_params.danger_pays": services.convert_multi_value(query.get("position__post__danger_pay__in")),
+        "fv_request_params.grades": services.convert_multi_value(query.get("position__grade__code__in")),
+        "fv_request_params.languages": services.convert_multi_value(query.get("language_codes")),
+        "fv_request_params.differential_pays": services.convert_multi_value(query.get("position__post__differential_rate__in")),
+        "fv_request_params.skills": services.convert_multi_value(query.get("position__skill__code__in")),
+        "fv_request_params.tod_codes": services.convert_multi_value(query.get("position__post__tour_of_duty__code__in")),
         "fv_request_params.location_codes": post_values(query),
-        "fv_request_params.pos_numbers": query.get("position__position_number__in", None),
-        "fv_request_params.seq_nums": query.get("id", None),
+        "fv_request_params.pos_numbers": services.convert_multi_value(query.get("position__position_number__in", None)),
+        "fv_request_params.seq_nums": services.convert_multi_value(query.get("id", None)),
     }
-    return urlencode({i: j for i, j in values.items() if j is not None})
+    return urlencode({i: j for i, j in values.items() if j is not None}, doseq=True)


### PR DESCRIPTION
* feature: adds position designations to cycle position stats. TM-695

* fix: filter designations by cycle and position

* fix: 404 if bidcycle or position cannot be found

* feature: handle errors that fsbid may raise when submitting a bid

* adds endpoint to view list of logs available and get the contents of a particular log

* remove unnecessary imports

* log entry model managed should be false

* fixing linting issues

* additional lint errors fixed

* adding endpoints for running data sync ad hoc

* forcing superuser permission and removing unused imports and functions

* fix: remove posted date from PV. TM-909 (#94)

* feature: add endpoints for getting and updating the about page content. TM-912 (#93)

* feature: add endpoints for getting and updating the about page content. TM-912

* chore: update comment

* Fix/realign pv values. TM-909 (#96)

* fix: remove posted date from PV. TM-909

* fix: projected vacancy data matching new FSBid endpoints. TM-909

* fix: a few updates from pr feedback

* added endpoint to run update_relationships command (#95)

* adding endpoint for update_string_representations command (#98)

* adding endpoint for update_string_representations command

* lint issue

* feature: allow for saving projected vacancies searches. TM-642

* fix: properly parse langualge string. correct field name error

* fix: remove null entries from lang. list

* fix: syntax

* feature: pv filtering for bureau hierarchy. TM-950

* chore: missed files

* chore: missed this as well

* Update apps.py

* fix: strip the end of the language text so there is no extra spaces

* chore: fix test data

* fix: fix PV favorites by using the id of the pv

* fix: send response object when no results are returned

* adding endpoints to edit SynchronizationJobs in DB and reset SynchronizationJob

* add use_last_date_updated as writable field, remove unnecesary filters

* removing reference to deleted filter class

* fix: correctly filter by location codes. TM-949

* fix: update the shape of the pv object to match new position shape (#109)

* fix: update availability to use cycle position to allow bidding

* updating response from data_sync list for conistency

* fix: use correct filter synatx

* chore: add cycle positions to the demo env setup

* chore: properly ref. the user first_name

* fix: process multiple filter values

* fix: position designations on cycle positions

* chore: fix formatting on files that are unchanged

* fix: query bids correctly for determining availability

* Create SynchronizationTask (#29)

* Create SynchronizationTask

* linting

* Testing saving task

* Fix merge issue

* Delete migration

* Re-make migration

* Remove Flask (#123)

* Linting (#115)

* Linting

* Linting

* removing historical assignments (#124)

* chore: update the demo environment task. TM-1115

* chore: add TED to cycle position

* save last_synchronization at beginning of process instead of end (#128)

* Added string representation to CyclePosition (#127)

* adding JWT to header for all calls to FSBid (#129)

* adding JWT to header for all calls to FSBid

* updating tests to pretend to use JWT

* Update/ad id in fsbid calls (#131)

* added ad_id to all fsbid calls

* escaping characters properly and updating url

* 🐛 Fix merge error 🐛

* 🐛 Fix merge 🐛

* adding admin view to check status of syncs

* cleaning out the dryer lint

* removing unnecessary pk value

* ESSR fixes for dev testing (#135)

* ESSR fixes for dev testing

* adding nosec

* fixing lint issues

* additional placeholder JWT

* adding obc_url to country and post (#136)

* adding obc_url to country and post

* Remove trailing slash

* Fix url slug

* chore: merge migrations to resolve conflict

* adding endpoints to track logins and unique logins (#139)

* adding endpoints to track logins and unique logins

* change submit to post, some additional cleanup

* Trigger notification

* ad_id -> fv_request_params.ad_id (#138)

* fix: do not use the bidcycle and position to determine uniquiness on a cycle position (#134)

* Override CORS headers

* fix: rename the jwt header sent to FSBid to match their naming. always send ad_id to the fsbid reqeuests

* Feature/jwtdecode (#143)

* decode jwt

* split services

* split services and update calls

* fix typo

* decode jwt

* split services

* split services and update calls

* fix typo

* chore: cleanup some tests and references to fake jwt that do not decode

* remove services file

* remove ad_id decode and header as it is not needed by fsbid

* fix: remove placeholders (#145)

* fix: renamed some fields to match fsbid field names

* fix: rename the field on the pv favories model

* Capture PV capsule description

* replacing verification

* fix: allow multiple filter values to be sent to fsbid as the same param. Addresses TM-1203 TM-1206

* chore: remove print stmt

* fix: map talentmap sort fields to fsbid sort fields

* fix: rename param. TM-1208

* fix: update the overseas filter (#156)