### PR TITLE
dev -> staging (#166)

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -32,7 +32,7 @@ source setup_environment.sh
 export DATABASE_URL='<DATABASE_URL>'
 export DJANGO_LOG_DIRECTORY='/home/ec2-user/log/'
 export DEPLOYMENT_LOCATION='/home/ec2-user/State-TalentMAP-API-dev/'
-export FSBID_API_URL='http://dev.talentmap.fsbid.metaphasedev.com'
+export FSBID_API_URL='https://mockfsbid.metaphasedev.com'
 
 # install dependencies
 pip install -r requirements.txt

--- a/talentmap_api/common/common_helpers.py
+++ b/talentmap_api/common/common_helpers.py
@@ -248,16 +248,7 @@ def get_filtered_queryset(filter_class, filters):
         5. Instantiate the subset filter class using query_params and the faked request
         6. Get the queryset from the filter class
     '''
-    new_filters = MultiValueDict()
-
-    for key, value in filters.items():
-        if isinstance(value, list):
-            new_filters.setlist(key, value)
-        else:
-            new_filters.appendlist(key, value)
-
-    query_params = QueryDict('', mutable=True)
-    query_params.update(new_filters)
+    query_params = format_filter(filters)
 
     # Your daily dose of python wizardry: https://docs.python.org/3/library/functions.html#type
     fake_request = type('obj', (object,), {'query_params': query_params})
@@ -270,6 +261,18 @@ def get_filtered_queryset(filter_class, filters):
 
     return queryset
 
+def format_filter(filters):
+    new_filters = MultiValueDict()
+
+    for key, value in filters.items():
+        if isinstance(value, list):
+            new_filters.setlist(key, value)
+        else:
+            new_filters.appendlist(key, value)
+
+    query_params = QueryDict('', mutable=True)
+    query_params.update(new_filters)
+    return query_params
 
 def get_permission_by_name(name):
     '''

--- a/talentmap_api/fsbid/filters.py
+++ b/talentmap_api/fsbid/filters.py
@@ -10,24 +10,20 @@ class ProjectedVacancyFilter():
     declared_filters = [
         "projectedVacancy",
         "is_available_in_bidseason",
-        "skill__code__in",
-        "grade__code__in",
-        "bureau__code__in",
-        "post__tour_of_duty__code__in",
+        "position__skill__code__in",
+        "position__grade__code__in",
+        "position__bureau__code__in",
+        "position__post__tour_of_duty__code__in",
         "language_codes",
-        "post__differential_rate__in",
-        "post__danger_pay__in",
+        "position__post__differential_rate__in",
+        "position__post__danger_pay__in",
     ]
 
     use_api = True
 
     # Used when saving a search to determine the number of records returned
-    def get_queryset(query):
-        def count(self):
-            fake_jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1bmlxdWVfbmFtZSI6IldBU0hEQ1xcVEVTVFVTRVIifQ.o5o4XZ3Z_vsqqC4a2tGcGEoYu3sSYxej4Y2GcCQVtyE"
-            return pv_services.get_projected_vacancies_count(query, fake_jwt)
-
-        return type('', (object,), {'count': count})()
+    def get_count(query, jwt_token):
+        return pv_services.get_projected_vacancies_count(query, jwt_token)
 
     class Meta:
         fields = "__all__"

--- a/talentmap_api/fsbid/services/available_positions.py
+++ b/talentmap_api/fsbid/services/available_positions.py
@@ -1,0 +1,233 @@
+import requests
+import re
+import logging
+
+from urllib.parse import urlencode
+
+from django.conf import settings
+from django.db.models import Q
+
+from talentmap_api.common.common_helpers import ensure_date
+from talentmap_api.organization.models import Post, Organization, OrganizationGroup
+import talentmap_api.fsbid.services.common as services
+
+API_ROOT = settings.FSBID_API_URL
+
+logger = logging.getLogger(__name__)
+
+
+def get_available_positions(query, jwt_token, host=None):
+    '''
+    Gets available positions from FSBid
+    '''
+    url = f"{API_ROOT}/availablePositions?{convert_ap_query(query)}"
+    response = requests.get(url, headers={'JWTAuthorization': jwt_token, 'Content-Type': 'application/json'}).json()
+
+    available_positions = map(fsbid_ap_to_talentmap_ap, response["Data"])
+    return {
+        **services.get_pagination(query, get_available_positions_count(query, jwt_token)['count'], "/api/v1/fsbid/available_positions/", host),
+        "results": available_positions
+    }
+
+
+def get_available_positions_count(query, jwt_token, host=None):
+    '''
+    Gets the total number of available positions for a filterset
+    '''
+    url = f"{API_ROOT}/availablePositionsCount?{convert_ap_query(query)}"
+    response = requests.get(url, headers={'JWTAuthorization': jwt_token, 'Content-Type': 'application/json'}).json()
+    return {"count": response["Data"][0]["count(1)"]}
+
+
+# Pattern for extracting language parts from a string. Ex. "Spanish (3/3)"
+LANG_PATTERN = re.compile("(.*?)\(.*\)\s(\d)/(\d)")
+
+
+def parseLanguage(lang):
+    '''
+    Parses a language string from FSBid and turns it into what we want
+    The lang param comes in as something like "Spanish (3/3)"
+    '''
+    if lang:
+        match = LANG_PATTERN.search(lang)
+        if match:
+            language = {}
+            language["language"] = match.group(1)
+            language["reading_proficiency"] = match.group(2)
+            language["spoken_proficiency"] = match.group(3)
+            language["representation"] = match.group(0).rstrip()
+            return language
+
+
+def fsbid_ap_to_talentmap_ap(ap):
+    '''
+    Converts the response available position from FSBid to a format more in line with the Talentmap position
+    '''
+    return {
+        "id": ap["cp_id"],
+        "status": "",
+        "status_code": ap["cp_status"],
+        "ted": ensure_date(ap["ted"], utc_offset=-5),
+        "posted_date": ensure_date(ap["cp_post_dt"], utc_offset=-5),
+        "availability": {
+            "availability": "",
+            "reason": ""
+        },
+        "is_urgent_vacancy": "",
+        "is_volunteer": "",
+        "is_hard_to_fill": "",
+        "position": {
+            "id": "",
+            "grade": ap["pos_grade_code"],
+            "skill": ap["pos_skill_desc"],
+            "bureau": ap["pos_bureau_short_desc"],
+            "organization": ap["post_org_country_state"],
+            "tour_of_duty": ap["tod"],
+            "classifications": "",
+            "representation": "",
+            "availability": {
+                "availability": "",
+                "reason": ""
+            },
+            "position_number": ap["position"],
+            "title": ap["pos_title_desc"],
+            "is_overseas": "",
+            "is_highlighted": "",
+            "create_date": "",
+            "update_date": "",
+            "effective_date": "",
+            "posted_date": ensure_date(ap["cp_post_dt"], utc_offset=-5),
+            "description": {
+                "id": "",
+                "last_editing_user": "",
+                "is_editable_by_user": "",
+                "date_created": "",
+                "date_updated": "",
+                "content": ap["ppos_capsule_descr_txt"],
+                "point_of_contact": "",
+                "website": ""
+            },
+            "current_assignment": {
+                "user": ap["incumbent"],
+                "tour_of_duty": ap["tod"],
+                "status": "",
+                "start_date": "",
+                "estimated_end_date": ensure_date(ap["ted"], utc_offset=-5)
+            },
+            "post": {
+                "id": "",
+                "code": ap["pos_location_code"],
+                "tour_of_duty": ap["tod"],
+                "post_overview_url": "",
+                "post_bidding_considerations_url": "",
+                "cost_of_living_adjustment": "",
+                "differential_rate": ap["bt_differential_rate_num"],
+                "danger_pay": ap["bt_danger_pay_num"],
+                "rest_relaxation_point": "",
+                "has_consumable_allowance": "",
+                "has_service_needs_differential": "",
+                "obc_id": "",
+                "location": {
+                    "id": "",
+                    "country": "",
+                    "code": "",
+                    "city": "",
+                    "state": ""
+                }
+            },
+            "latest_bidcycle": {
+                "id": ap["cycle_id"],
+                "name": ap["cycle_nm_txt"],
+                "cycle_start_date": "",
+                "cycle_deadline_date": "",
+                "cycle_end_date": "",
+                "active": ""
+            },
+            "languages": list(filter(None, [
+                parseLanguage(ap["lang1"]),
+                parseLanguage(ap["lang2"]),
+            ])),
+        },
+        "bidcycle": {
+            "id": ap["cycle_id"],
+            "name": ap["cycle_nm_txt"],
+            "cycle_start_date": "",
+            "cycle_deadline_date": "",
+            "cycle_end_date": "",
+            "active": ""
+        },
+        "bid_statistics": {
+            "id": "",
+            "total_bids": ap["cp_ttl_bidder_qty"],
+            "in_grade": ap["cp_at_grd_qty"],
+            "at_skill": ap["cp_in_cone_qty"],
+            "in_grade_at_skill": ap["cp_at_grd_in_cone_qty"],
+            "has_handshake_offered": "",
+            "has_handshake_accepted": ""
+        }
+    }
+
+
+def post_values(query):
+    '''
+    Handles mapping locations and groups of locations to FSBid expected params
+    '''
+    results = []
+    if query.get("is_domestic") == "true":
+        domestic_codes = Post.objects.filter(location__country__code="USA").values_list("_location_code", flat=True)
+        results = results + list(domestic_codes)
+    if query.get("is_domestic") == "false":
+        overseas_codes = Post.objects.exclude(location__country__code="USA").values_list("_location_code", flat=True)
+        results = results + list(overseas_codes)
+    if query.get("position__post__in"):
+        post_ids = query.get("position__post__in").split(",")
+        location_codes = Post.objects.filter(id__in=post_ids).values_list("_location_code", flat=True)
+        results = results + list(location_codes)
+    if len(results) > 0:
+        return ",".join(results)
+
+
+def bureau_values(query):
+    '''
+    Gets the ids for the functional/regional bureaus and maps to codes and their children
+    '''
+    results = []
+    # functional bureau filter
+    if query.get("org_has_groups"):
+        func_bureaus = query.get("org_has_groups").split(",")
+        func_org_codes = OrganizationGroup.objects.filter(id__in=func_bureaus).values_list("_org_codes", flat=True)
+        # Flatten _org_codes
+        func_bureau_codes = [item for sublist in func_org_codes for item in sublist]
+        results = results + list(func_bureau_codes)
+    # Regional bureau filter
+    if query.get("position__bureau__code__in"):
+        regional_bureaus = query.get("position__bureau__code__in").split(",")
+        reg_org_codes = Organization.objects.filter(Q(code__in=regional_bureaus) | Q(_parent_organization_code__in=regional_bureaus)).values_list("code", flat=True)
+        results = results + list(reg_org_codes)
+    if len(results) > 0:
+        return ",".join(results)
+
+
+def convert_ap_query(query):
+    '''
+    Converts TalentMap filters into FSBid filters
+
+    The TalentMap filters align with the position search filter naming
+    '''
+    values = {
+        "request_params.page_index": int(query.get("page", 1)),
+        "request_params.page_size": query.get("limit", 25),
+        "request_params.freeText": query.get("q", None),
+        "request_params.bid_seasons": query.get("is_available_in_bidseason"),
+        "request_params.bureaus": bureau_values(query),
+        "request_params.danger_pays": query.get("position__post__danger_pay__in"),
+        "request_params.grades": query.get("position__grade__code__in"),
+        "request_params.languages": query.get("language_codes"),
+        "request_params.differential_pays": query.get("position__post__differential_rate__in"),
+        "request_params.skills": query.get("position__skill__code__in"),
+        "request_params.tod_codes": query.get("position__post__tour_of_duty__code__in"),
+        "request_params.location_codes": post_values(query),
+        "request_params.pos_numbers": query.get("position__position_number__in", None),
+        "request_params.cp_ids": query.get("id", None),
+    }
+    return urlencode({i: j for i, j in values.items() if j is not None})

--- a/talentmap_api/fsbid/urls/available_positions.py
+++ b/talentmap_api/fsbid/urls/available_positions.py
@@ -1,0 +1,12 @@
+from django.conf.urls import url
+from rest_framework import routers
+
+from talentmap_api.fsbid.views import available_positions as views
+
+router = routers.SimpleRouter()
+
+urlpatterns = [
+    url(r'', views.FSBidAvailablePositionsListView.as_view(), name="available-positions-FSBid-available-positions-actions"),
+]
+
+urlpatterns += router.urls

--- a/talentmap_api/fsbid/views/available_positions.py
+++ b/talentmap_api/fsbid/views/available_positions.py
@@ -1,0 +1,36 @@
+from dateutil.relativedelta import relativedelta
+
+from django.shortcuts import get_object_or_404
+from django.core.exceptions import PermissionDenied
+from django.utils import timezone
+
+from rest_framework.viewsets import GenericViewSet
+from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly
+
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+
+from talentmap_api.user_profile.models import UserProfile
+from talentmap_api.fsbid.filters import ProjectedVacancyFilter
+
+import talentmap_api.fsbid.services.available_positions as services
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+class FSBidAvailablePositionsListView(APIView):
+
+    permission_classes = (IsAuthenticatedOrReadOnly,)
+    filter_class = ProjectedVacancyFilter
+
+    @classmethod
+    def get_extra_actions(cls):
+        return []
+
+    def get(self, request, *args, **kwargs):
+        '''
+        Gets all available positions
+        '''
+        return Response(services.get_available_positions(request.query_params, 'JWTPLACEHOLDER', f"{request.scheme}://{request.get_host()}"))

--- a/talentmap_api/integrations/synchronization_helpers.py
+++ b/talentmap_api/integrations/synchronization_helpers.py
@@ -539,14 +539,24 @@ def mode_cycle_positions(last_updated_date=None):
 
         if position:
             updated_instances.append(position)
-            cycle_position, _ = CyclePosition.objects.get_or_create(_cp_id=data["CP_ID"])
-            cycle_position.position = position
-            cycle_position.bidcycle = bc
-            cycle_position.status_code = data["STATUS_CODE"]
-            cycle_position.status = data["STATUS"]
-            cycle_position.created = ensure_date(data["DATE_CREATED"], utc_offset=-5)
-            cycle_position.updated = ensure_date(data["DATE_UPDATED"], utc_offset=-5)
-            cycle_position.posted_date = ensure_date(data["CP_POST_DT"], utc_offset=-5)
+            cycle_position, _ = CyclePosition.objects.get_or_create(_cp_id=data["CP_ID"], defaults={
+                'position': position,
+                'bidcycle': bc,
+                'status_code': data["STATUS_CODE"],
+                'status': data["STATUS"],
+                'created': ensure_date(data["DATE_CREATED"], utc_offset=-5),
+                'updated': ensure_date(data["DATE_UPDATED"], utc_offset=-5),
+                'posted_date': ensure_date(data["CP_POST_DT"], utc_offset=-5)
+            })
+            # if the CP was found, update it
+            if _ is False:
+                cycle_position.position = position
+                cycle_position.bidcycle = bc
+                cycle_position.status_code = data["STATUS_CODE"]
+                cycle_position.status = data["STATUS"]
+                cycle_position.created = ensure_date(data["DATE_CREATED"], utc_offset=-5)
+                cycle_position.updated = ensure_date(data["DATE_UPDATED"], utc_offset=-5)
+                cycle_position.posted_date = ensure_date(data["CP_POST_DT"], utc_offset=-5)
             position.effective_date = ensure_date(data["DATE_UPDATED"], utc_offset=-5)
             position.posted_date = ensure_date(data["CP_POST_DT"], utc_offset=-5)
             position.save()

--- a/talentmap_api/settings.py
+++ b/talentmap_api/settings.py
@@ -490,3 +490,14 @@ CORS_ALLOW_HEADERS = [
 'x-csrftoken',
 'x-requested-with',
 ]
+
+SWAGGER_SETTINGS = {
+    'SECURITY_DEFINITIONS': {
+        "api_key": {
+            "type": "apiKey",
+            "name": "JWT",
+            "in": "header",
+            "description": "JWT authorization"
+        },
+    },
+}

--- a/talentmap_api/urls.py
+++ b/talentmap_api/urls.py
@@ -43,6 +43,7 @@ urlpatterns = [
     # FSBId
     url(r'^api/v1/fsbid/bidlist/', include('talentmap_api.fsbid.urls.bidlist')),
     url(r'^api/v1/fsbid/projected_vacancies', include('talentmap_api.fsbid.urls.projected_vacancies')),
+    url(r'^api/v1/fsbid/available_positions', include('talentmap_api.fsbid.urls.available_positions')),
     url(r'^api/v1/fsbid/bid_seasons', include('talentmap_api.fsbid.urls.bid_seasons')),
 
     # Projected Vacancies

--- a/talentmap_api/user_profile/serializers.py
+++ b/talentmap_api/user_profile/serializers.py
@@ -216,6 +216,10 @@ class UserProfileWritableSerializer(PrefetchedSerializer):
 class SavedSearchSerializer(PrefetchedSerializer):
     owner = serializers.StringRelatedField(read_only=True)
 
+    def save(self, **kwargs):
+        super().save(owner=kwargs['owner'])
+        self.instance.update_count(True, kwargs['jwt_token'])
+
     def validate(self, data):
         # We'll need the endpoint to validate our filters, so determine if our
         # datasource is an instance or a fresh object (in which case we use initial data)

--- a/talentmap_api/user_profile/tests/test_saved_searches.py
+++ b/talentmap_api/user_profile/tests/test_saved_searches.py
@@ -84,7 +84,7 @@ def test_saved_search_create_in_array_filters(authorized_client, authorized_user
                 "grade__code__in": ["05", "06"]
             }
         }
-    ), content_type='application/json')
+    ), content_type='application/json', HTTP_JWT='test')
 
     assert response.status_code == status.HTTP_201_CREATED
 
@@ -100,7 +100,7 @@ def test_saved_search_create_in_string_filters(authorized_client, authorized_use
                 "post__in": "254,123"
             }
         }
-    ), content_type='application/json')
+    ), content_type='application/json', HTTP_JWT='test')
 
     assert response.status_code == status.HTTP_201_CREATED
 
@@ -116,7 +116,7 @@ def test_saved_search_create_declared_filters(authorized_client, authorized_user
                 "q": ["german security"]
             }
         }
-    ), content_type='application/json')
+    ), content_type='application/json', HTTP_JWT='test')
 
     assert response.status_code == status.HTTP_201_CREATED
 
@@ -134,7 +134,7 @@ def test_saved_search_create_valid_filters(authorized_client, authorized_user):
                 "post__tour_of_duty__months__gt": ["6"]
             }
         }
-    ), content_type='application/json')
+    ), content_type='application/json', HTTP_JWT='test')
 
     assert response.status_code == status.HTTP_201_CREATED
 
@@ -177,7 +177,7 @@ def test_saved_search_patch_valid_filters(authorized_client, authorized_user, te
                 "bureau_organization__code__contains": ["6"]
             }
         }
-    ), content_type='application/json')
+    ), content_type='application/json', HTTP_JWT='test')
 
     assert response.status_code == status.HTTP_200_OK
 

--- a/talentmap_api/user_profile/views/searches.py
+++ b/talentmap_api/user_profile/views/searches.py
@@ -37,7 +37,10 @@ class SavedSearchView(FieldLimitableSerializerMixin,
     permission_classes = (IsAuthenticated,)
 
     def perform_create(self, serializer):
-        serializer.save(owner=self.request.user.profile)
+        serializer.save(owner=self.request.user.profile, jwt_token=self.request.META['HTTP_JWT'])
+
+    def perform_update(self, serializer):
+        serializer.save(owner=self.request.user.profile, jwt_token=self.request.META['HTTP_JWT'])
 
     def get_queryset(self):
         return get_prefetched_filtered_queryset(SavedSearch, self.serializer_class, owner=self.request.user.profile)


### PR DESCRIPTION
* feature: adds position designations to cycle position stats. TM-695

* fix: filter designations by cycle and position

* fix: 404 if bidcycle or position cannot be found

* feature: handle errors that fsbid may raise when submitting a bid

* adds endpoint to view list of logs available and get the contents of a particular log

* remove unnecessary imports

* log entry model managed should be false

* fixing linting issues

* additional lint errors fixed

* adding endpoints for running data sync ad hoc

* forcing superuser permission and removing unused imports and functions

* fix: remove posted date from PV. TM-909 (#94)

* feature: add endpoints for getting and updating the about page content. TM-912 (#93)

* feature: add endpoints for getting and updating the about page content. TM-912

* chore: update comment

* Fix/realign pv values. TM-909 (#96)

* fix: remove posted date from PV. TM-909

* fix: projected vacancy data matching new FSBid endpoints. TM-909

* fix: a few updates from pr feedback

* added endpoint to run update_relationships command (#95)

* adding endpoint for update_string_representations command (#98)

* adding endpoint for update_string_representations command

* lint issue

* feature: allow for saving projected vacancies searches. TM-642

* fix: properly parse langualge string. correct field name error

* fix: remove null entries from lang. list

* fix: syntax

* feature: pv filtering for bureau hierarchy. TM-950

* chore: missed files

* chore: missed this as well

* Update apps.py

* fix: strip the end of the language text so there is no extra spaces

* chore: fix test data

* fix: fix PV favorites by using the id of the pv

* fix: send response object when no results are returned

* adding endpoints to edit SynchronizationJobs in DB and reset SynchronizationJob

* add use_last_date_updated as writable field, remove unnecesary filters

* removing reference to deleted filter class

* fix: correctly filter by location codes. TM-949

* fix: update the shape of the pv object to match new position shape (#109)

* fix: update availability to use cycle position to allow bidding

* updating response from data_sync list for conistency

* fix: use correct filter synatx

* chore: add cycle positions to the demo env setup

* chore: properly ref. the user first_name

* fix: process multiple filter values

* fix: position designations on cycle positions

* chore: fix formatting on files that are unchanged

* fix: query bids correctly for determining availability

* Create SynchronizationTask (#29)

* Create SynchronizationTask

* linting

* Testing saving task

* Fix merge issue

* Delete migration

* Re-make migration

* Remove Flask (#123)

* Linting (#115)

* Linting

* Linting

* removing historical assignments (#124)

* chore: update the demo environment task. TM-1115

* chore: add TED to cycle position

* save last_synchronization at beginning of process instead of end (#128)

* Added string representation to CyclePosition (#127)

* adding JWT to header for all calls to FSBid (#129)

* adding JWT to header for all calls to FSBid

* updating tests to pretend to use JWT

* Update/ad id in fsbid calls (#131)

* added ad_id to all fsbid calls

* escaping characters properly and updating url

* 🐛 Fix merge error 🐛

* 🐛 Fix merge 🐛

* adding admin view to check status of syncs

* cleaning out the dryer lint

* removing unnecessary pk value

* ESSR fixes for dev testing (#135)

* ESSR fixes for dev testing

* adding nosec

* fixing lint issues

* additional placeholder JWT

* adding obc_url to country and post (#136)

* adding obc_url to country and post

* Remove trailing slash

* Fix url slug

* chore: merge migrations to resolve conflict

* adding endpoints to track logins and unique logins (#139)

* adding endpoints to track logins and unique logins

* change submit to post, some additional cleanup

* Trigger notification

* ad_id -> fv_request_params.ad_id (#138)

* fix: do not use the bidcycle and position to determine uniquiness on a cycle position (#134)

* Override CORS headers

* fix: rename the jwt header sent to FSBid to match their naming. always send ad_id to the fsbid reqeuests

* Feature/jwtdecode (#143)

* decode jwt

* split services

* split services and update calls

* fix typo

* decode jwt

* split services

* split services and update calls

* fix typo

* chore: cleanup some tests and references to fake jwt that do not decode

* remove services file

* remove ad_id decode and header as it is not needed by fsbid

* fix: remove placeholders (#145)

* fix: renamed some fields to match fsbid field names

* fix: rename the field on the pv favories model

* Capture PV capsule description

* replacing verification

* fix: allow multiple filter values to be sent to fsbid as the same param. Addresses TM-1203 TM-1206

* chore: remove print stmt

* fix: map talentmap sort fields to fsbid sort fields

* fix: rename param. TM-1208

* first go at available positions dynamic api

* chore: update dev url for mock fsbid

* fix: update field mappings for available positions

* fix: update the overseas filter (#156)

* update_count now using jwt token

* update testing scripts

* fix: add defaults to the get_or_create on cycle position so it doesnt error

* fix: account for updates on the CP as well

* updating description

* update filters

* fix count to save on creation

* adding bidding statistics

* chore: allow for jwt to be set for swagger calls via authorize (#167)