### PR TITLE
dev -> staging (#213)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,8 @@ jobs:
             . venv/bin/activate
             mkdir ./tmp-pip
             pip install -r requirements.txt -t ./tmp-pip
-            zip talentmap-api-dependencies.zip -r ./tmp-pip/*
+            cd ./tmp-pip
+            zip -r ../talentmap-api-dependencies.zip * .[^.]*
       - store_artifacts:
           path: talentmap-api-dependencies.zip
           destination: talentmap-api-dependencies.zip

--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -132,8 +132,8 @@ def sorting_values(sort):
 def get_results(uri, query, query_mapping_function, jwt_token, mapping_function):
     url = f"{API_ROOT}/{uri}?{query_mapping_function(query)}"
     response = requests.get(url, headers={'JWTAuthorization': jwt_token, 'Content-Type': 'application/json'}, verify=False).json()  # nosec
-
     if response.get("Data") is None or response.get('return_code', -1) == -1:
+        logger.error(f"Fsbid call to '{url}' failed.")
         return None
 
     return list(map(mapping_function, response.get("Data", {})))
@@ -143,6 +143,7 @@ def get_fsbid_results(uri, jwt_token, mapping_function):
     response = requests.get(url, headers={'JWTAuthorization': jwt_token, 'Content-Type': 'application/json'}, verify=False).json() # nosec
     
     if response.get("Data") is None or response.get('return_code', -1) == -1:
+        logger.error(f"Fsbid call to '{url}' failed.")
         return None
  
     return map(mapping_function, response.get("Data", {}))
@@ -182,6 +183,7 @@ def send_get_csv_request(uri, query, query_mapping_function, jwt_token, mapping_
     response = requests.get(url, headers={'JWTAuthorization': jwt_token, 'Content-Type': 'application/json'}).json()
 
     if response.get("Data") is None or response.get('return_code', -1) == -1:
+        logger.error(f"Fsbid call to '{url}' failed.")
         return None
 
     return map(mapping_function, response.get("Data", {}))


### PR DESCRIPTION
* chore: refactor common functions into common file

* chore: refactor commonn get and count functions

* fix: make requests a little more robust

* adding bidding statistics

* fix: update test

* feature: new model for available position designations which includes highlighting. TM-695

* chore: allow for jwt to be set for swagger calls via authorize (#167)

* fix: update the regex to parse out the language code and reconstruct the representation with better formatting

* fix: add the designations to the returned available_positions data

* fix: use filter+first in case the designation object is not in the db

* add new filter class for available positions that uses the api

* feature: add get individual available position and get similar available positions

* fix: remove history fields and tables that we are no longer using

* chore: missed one file

* fix: missed this one

* add swagger fields

* fix: remove string representations from models that do not require it

* feature: allow for the update relationships sql to be run via a python command

* fix: fix tests and migration conflicts

* fix: update the string representations command to accept a model and only run on that model

* feature: update_relationships command accepts an optional model param to process only that model

* fix: process the response from the fsbid api correctly

* fix: display available options

* chore: add guidance on what are acceptable models]

* fix: fix param parsing on the available position params

* adding export for available positions

* clean up

* updating test to use new endpoint

* feature: get an individual projected vacancy.

* fix: date parsing on the bid season

* remove unneeded f

* fix: return 404 when no pv/ap with id is found

* cleaning up lint issues

* fix: ensure date now returns None rather than raising Exception

* fix: fix the sorting on projected vacancies. TM-1275

* Trigger notification

* Trigger notification

* fix: add location mapping to the projected vacancy. TM-1274

* fix: add verify=False to requests to fsbid

* Revert "fix: add verify=False to requests to fsbid"

This reverts commit aaa689bbdde948e817e21aeb49cc91028a69073c.

* fix: add the verify=false to the fsbid requests

* chore: nosec on verify=False lines

* add api endpoint for updating savedsearch counts

* fix: remove the assignment model and all things associated

* update endpoint

* fix: add to user profile route

* fix: handle multiple favorites

* fix: return all position designations

* safe navigation to the location of the projected vacancy

* fixing bad merge and updating export format

* fix: only return the favorite ids for the profile to shrink the payload

* feature: sort bid season on description

* chore: cleanups for sync things (#189)

* fix: fix the bureau filter on PV

* chore: remove oracle realted files

* fix: use no langage code from fsbid for checking for no language

* only update counts for user

* feature: capture ids as a filter used in comparision

* lint issues

* retrieve reference data from fsbid

* Add middleware to expose Content-Disposition header

* fix: add the about page editor group to the allowed permissions

* update filename and languages

* add remaining fsbid calls

* fix: add the about page editor group to the allowed permissions

* fix: add permission group for editing the about page. TM-1271

* refactor duplicate code

* fix language_code

* fix: comment out code that was breaking sync (#195)

* fix: return a value so things dont break

* feature: add endpoint to update user profile emp_id with perdet_seq_num from fsbid

* chore: revert files added unintentionally

* update dictionary retrieval to error check

* fix: cleanup bidding and fsbid mappings

* fix: add additional fields

* chore:minor refactoring on the similar positions logic

* fix: fix the cycle filters for available positions

* fix: return favorites as part of the user profile payload

* Pip requirements will get cached between docker-compose builds (#200)

* fix: allow for location code to be passed to post available position filter. this happens when searching for similar positions

* fix: sort bureau on the short description

* refactor to add error checking

* test file changes

* correctly updating test files this time

* fix: allow sorting on posted_date

* update to have none as default

* codes

* chore: use a docker image rather than require the mock code to be checked out (#150)

* chore: use a docker image rather than require the mock code to be checked out

* fix: move back to mock_fsbid url so containers can still talk to each other;

* feature: allow mock-fsbid to be run from local code if needed

* chore: improve the performance of the string_rep job by forcing update and limiting the fields being updated (#169)

* available positions file switch to none

* First attempt at zipping pip dependencies

* docker step

* Temporarily new steps move to build process for testing

* Testing the branch filter

* Remove branch filter for testing

* Test for only branch

* Fix only branch filter

* Run on all branches (for now)

* update naming: site -> dependencies

* log the errors

* Try to pull down hidden files (#212)