### PR TITLE
dev -> staging (#240)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,7 @@ Jinja2==2.10
 locustio==0.8.1
 lxml==4.2.1
 MarkupSafe==1.0
+maya==0.6.1
 model-mommy==1.5.1
 more-itertools==4.1.0
 msgpack-python==0.5.6

--- a/talentmap_api/fsbid/services/available_positions.py
+++ b/talentmap_api/fsbid/services/available_positions.py
@@ -2,6 +2,7 @@ import requests
 import logging
 import csv
 from datetime import datetime
+import maya
 
 from urllib.parse import urlencode, quote
 
@@ -111,10 +112,10 @@ def get_available_positions_csv(query, jwt_token, host=None):
             smart_str(record["position"]["post"]["has_service_needs_differential"]),
             smart_str(record["position"]["post"]["differential_rate"]),
             smart_str(record["position"]["post"]["danger_pay"]),
-            smart_str(record["ted"].strftime('%m/%d/%Y')),
+            smart_str(maya.parse(record["ted"]).datetime().strftime('%m/%d/%Y')),
             smart_str(record["position"]["current_assignment"]["user"]),
             smart_str(record["bidcycle"]["name"]),
-            smart_str(record["posted_date"].strftime('%m/%d/%Y')),
+            smart_str(maya.parse(record["posted_date"]).datetime().strftime('%m/%d/%Y')),
             smart_str(record["status_code"]),
             smart_str(record["position"]["description"]["content"]),
         ])

--- a/talentmap_api/fsbid/services/reference.py
+++ b/talentmap_api/fsbid/services/reference.py
@@ -101,10 +101,9 @@ def fsbid_codes_to_talentmap_cones(data):
 @staticmethod
 def fsbid_locations_to_talentmap_locations(data):
     return {
-        "code": data.get("code", 0),
-        "city": data.get("city", None),
-        "state": data.get("state", None),
-        "country": data.get("country", None),
+        "code": data.get("location_code", 0),
+        "city": data.get("location_city", None),
+        "state": data.get("location_state", None),
+        "country": data.get("location_country", None),
         "is_domestic": data.get("is_domestic", None) == 1,
     }
-

--- a/talentmap_api/fsbid/tests/test_fsbid_reference.py
+++ b/talentmap_api/fsbid/tests/test_fsbid_reference.py
@@ -7,14 +7,11 @@ fake_jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1bmlxdWVfbmFtZSI6IldBU0hEQ1x
 @pytest.mark.django_db(transaction=True)
 def test_fsbid_locations(authorized_client, authorized_user):
     with patch('talentmap_api.fsbid.services.common.requests.get') as mock_get:
-      locations = [{"code": '12345', "city": "Washington", "state": "DC", "country": "United States", "is_domestic": 1}]
+      locations = [{"location_code": '12345', "location_city": "Washington", "location_state": "DC", "location_country": "United States", "is_domestic": 1}]
       mock_get.return_value = Mock(ok=True)
       mock_get.return_value.json.return_value = {"Data": locations, "return_code": 0 }
       response = authorized_client.get('/api/v1/fsbid/reference/locations/', HTTP_JWT=fake_jwt)
       assert response.status_code == status.HTTP_200_OK
       data = response.json()[0]
-      assert data['code'] == locations[0]['code']
+      assert data['code'] == locations[0]['location_code']
       assert data['is_domestic'] is True
-
-
-

--- a/talentmap_api/fsbid/views/reference.py
+++ b/talentmap_api/fsbid/views/reference.py
@@ -39,21 +39,20 @@ class FSBidLanguagesView(BaseView):
 class FSBidTourOfDutiesView(BaseView):
     uri = "tourofduties"
     mapping_function = services.fsbid_tour_of_duties_to_talentmap_tour_of_duties
-    
+
 class FSBidCodesView(BaseView):
     uri = "skillCodes"
     mapping_function = services.fsbid_codes_to_talentmap_codes
-    
+
 class FSBidLocationsView(BaseView):
     uri = "locations"
     mapping_function = services.fsbid_locations_to_talentmap_locations
 
 class FSBidConesView(BaseView):
-    uri = "codes"
+    uri = "skillCodes"
     mapping_function = services.fsbid_codes_to_talentmap_cones
 
-    def ModConesResults(self, results):
-        
+    def modCones(self, results):
         results = list(results)
         values = set(map(lambda x: x['category'], results))
 
@@ -62,10 +61,9 @@ class FSBidConesView(BaseView):
             for info in results:
                 if info['category'] == cone:
                     codes.append({'code': info['code'], 'id': info['id'], 'description': info['description']})
-            
+
             newlist.append({'category': cone, 'skills': codes})
             codes = []
-        
         return newlist
-    
-    mod_function = ModConesResults
+
+    mod_function = modCones


### PR DESCRIPTION
* Trigger notification

* fix: add location mapping to the projected vacancy. TM-1274

* fix: add verify=False to requests to fsbid

* Revert "fix: add verify=False to requests to fsbid"

This reverts commit aaa689bbdde948e817e21aeb49cc91028a69073c.

* fix: add the verify=false to the fsbid requests

* chore: nosec on verify=False lines

* add api endpoint for updating savedsearch counts

* fix: remove the assignment model and all things associated

* update endpoint

* fix: add to user profile route

* fix: handle multiple favorites

* fix: return all position designations

* safe navigation to the location of the projected vacancy

* fixing bad merge and updating export format

* fix: only return the favorite ids for the profile to shrink the payload

* feature: sort bid season on description

* chore: cleanups for sync things (#189)

* fix: fix the bureau filter on PV

* chore: remove oracle realted files

* fix: use no langage code from fsbid for checking for no language

* only update counts for user

* feature: capture ids as a filter used in comparision

* lint issues

* retrieve reference data from fsbid

* Add middleware to expose Content-Disposition header

* fix: add the about page editor group to the allowed permissions

* update filename and languages

* add remaining fsbid calls

* fix: add the about page editor group to the allowed permissions

* fix: add permission group for editing the about page. TM-1271

* refactor duplicate code

* fix language_code

* fix: comment out code that was breaking sync (#195)

* fix: return a value so things dont break

* feature: add endpoint to update user profile emp_id with perdet_seq_num from fsbid

* chore: revert files added unintentionally

* update dictionary retrieval to error check

* fix: cleanup bidding and fsbid mappings

* fix: add additional fields

* chore:minor refactoring on the similar positions logic

* fix: fix the cycle filters for available positions

* fix: return favorites as part of the user profile payload

* Pip requirements will get cached between docker-compose builds (#200)

* fix: allow for location code to be passed to post available position filter. this happens when searching for similar positions

* fix: sort bureau on the short description

* refactor to add error checking

* test file changes

* correctly updating test files this time

* fix: allow sorting on posted_date

* update to have none as default

* codes

* chore: use a docker image rather than require the mock code to be checked out (#150)

* chore: use a docker image rather than require the mock code to be checked out

* fix: move back to mock_fsbid url so containers can still talk to each other;

* feature: allow mock-fsbid to be run from local code if needed

* chore: improve the performance of the string_rep job by forcing update and limiting the fields being updated (#169)

* available positions file switch to none

* First attempt at zipping pip dependencies

* docker step

* Temporarily new steps move to build process for testing

* Testing the branch filter

* Remove branch filter for testing

* Test for only branch

* Fix only branch filter

* Run on all branches (for now)

* update naming: site -> dependencies

* log the errors

* Try to pull down hidden files (#212)

* fix: add the ad_id param to the bidding endpoint queries to send it to the server to support CDO bidding

* add location information

* Add verify=false to available positions export endpoint

* fix: cast the count var to an int

* chore: use a docker image rather than require the mock code to be checked out

* fix: move back to mock_fsbid url so containers can still talk to each other;

* feature: allow mock-fsbid to be run from local code if needed

* Add #nosec for bandit

* chore: setup docker for new mock-fsbid

* feature: get the role from the jwt and assign talentmap role

* fix: fix config for the mock

* fix: add skill number to skill value

* fix: add the capsule description update date to the responses

* TM-1380 fix bureaus

* chore: add debug env value

* fix: use new broken down location field

* fix: add skill code to the pv payload

* chore: use a correct volumne for mock db

* TM 1339 Add short description to the long description

* feature: add endpoint for getting location data from fsbid

* feature: download and properly stream zipped files to the log download

* fix: add the correct bureau information to the pv and ap response

* fix: ensure the is_cdo function works with new cdo role

* fix: allow the url to accept the extension of the file

* fix: fix the cycle filter

* fix: use country from api

* fix: comma

* TM-1293 add cones endpoint

* add a modification function to the base class

* fix: format the bidlist data

* update naming

* fix: make the skill code endpoint call the renamed fsbid endpoint

* Include capsule description in export

* update the cones endpoint

* whoops, included things I was testing

* darn testing changes

* Use correct prop names for mapping locations

* Datetime parsing with the maya library. Needed for questionable date formats

* Update test with new location data

* dev -> staging (#236) (#241)

* remove unneeded f

* fix: return 404 when no pv/ap with id is found

* cleaning up lint issues

* fix: ensure date now returns None rather than raising Exception

* fix: fix the sorting on projected vacancies. TM-1275

* Trigger notification

* Trigger notification

* fix: add location mapping to the projected vacancy. TM-1274

* fix: add verify=False to requests to fsbid

* Revert "fix: add verify=False to requests to fsbid"

This reverts commit aaa689bbdde948e817e21aeb49cc91028a69073c.

* fix: add the verify=false to the fsbid requests

* chore: nosec on verify=False lines

* add api endpoint for updating savedsearch counts

* fix: remove the assignment model and all things associated

* update endpoint

* fix: add to user profile route

* fix: handle multiple favorites

* fix: return all position designations

* safe navigation to the location of the projected vacancy

* fixing bad merge and updating export format

* fix: only return the favorite ids for the profile to shrink the payload

* feature: sort bid season on description

* chore: cleanups for sync things (#189)

* fix: fix the bureau filter on PV

* chore: remove oracle realted files

* fix: use no langage code from fsbid for checking for no language

* only update counts for user

* feature: capture ids as a filter used in comparision

* lint issues

* retrieve reference data from fsbid

* Add middleware to expose Content-Disposition header

* fix: add the about page editor group to the allowed permissions

* update filename and languages

* add remaining fsbid calls

* fix: add the about page editor group to the allowed permissions

* fix: add permission group for editing the about page. TM-1271

* refactor duplicate code

* fix language_code

* fix: comment out code that was breaking sync (#195)

* fix: return a value so things dont break

* feature: add endpoint to update user profile emp_id with perdet_seq_num from fsbid

* chore: revert files added unintentionally

* update dictionary retrieval to error check

* fix: cleanup bidding and fsbid mappings

* fix: add additional fields

* chore:minor refactoring on the similar positions logic

* fix: fix the cycle filters for available positions

* fix: return favorites as part of the user profile payload

* Pip requirements will get cached between docker-compose builds (#200)

* fix: allow for location code to be passed to post available position filter. this happens when searching for similar positions

* fix: sort bureau on the short description

* refactor to add error checking

* test file changes

* correctly updating test files this time

* fix: allow sorting on posted_date

* update to have none as default

* codes

* chore: use a docker image rather than require the mock code to be checked out (#150)

* chore: use a docker image rather than require the mock code to be checked out

* fix: move back to mock_fsbid url so containers can still talk to each other;

* feature: allow mock-fsbid to be run from local code if needed

* chore: improve the performance of the string_rep job by forcing update and limiting the fields being updated (#169)

* available positions file switch to none

* First attempt at zipping pip dependencies

* docker step

* Temporarily new steps move to build process for testing

* Testing the branch filter

* Remove branch filter for testing

* Test for only branch

* Fix only branch filter

* Run on all branches (for now)

* update naming: site -> dependencies

* log the errors

* Try to pull down hidden files (#212)

* fix: add the ad_id param to the bidding endpoint queries to send it to the server to support CDO bidding

* add location information

* Add verify=false to available positions export endpoint

* fix: cast the count var to an int

* chore: use a docker image rather than require the mock code to be checked out

* fix: move back to mock_fsbid url so containers can still talk to each other;

* feature: allow mock-fsbid to be run from local code if needed

* Add #nosec for bandit

* chore: setup docker for new mock-fsbid

* feature: get the role from the jwt and assign talentmap role

* fix: fix config for the mock

* fix: add skill number to skill value

* fix: add the capsule description update date to the responses

* TM-1380 fix bureaus

* chore: add debug env value

* fix: use new broken down location field

* fix: add skill code to the pv payload

* chore: use a correct volumne for mock db

* TM 1339 Add short description to the long description

* feature: add endpoint for getting location data from fsbid

* feature: download and properly stream zipped files to the log download

* fix: add the correct bureau information to the pv and ap response

* fix: ensure the is_cdo function works with new cdo role

* fix: allow the url to accept the extension of the file

* fix: fix the cycle filter

* fix: use country from api

* fix: comma

* TM-1293 add cones endpoint

* add a modification function to the base class

* fix: format the bidlist data

* update naming

* fix: make the skill code endpoint call the renamed fsbid endpoint

* Include capsule description in export