### PR TITLE
dev -> staging (#270)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ missing_coverage.sh
 setup_environment.sh
 
 talentmap_api/saml2/remote_metadata/remote_metadata.xml
+
+#Test_Data
+talentmap_api/data/test_data/real/

--- a/EXAMPLE_setup_environment.sh
+++ b/EXAMPLE_setup_environment.sh
@@ -109,4 +109,6 @@ export SAML2_ADMINISTRATIVE_POC_COMPANY=''
 export SAML2_ADMINISTRATIVE_POC_EMAIL=''
 
 export FSBID_API_URL='http://mock_fsbid:3333'
+export EMPLOYEES_API_URL='http://mock_fsbid:3333/Employees'
+
 export OBC_URL='http://localhost:4000'

--- a/deploy.sh
+++ b/deploy.sh
@@ -33,6 +33,7 @@ export DATABASE_URL='<DATABASE_URL>'
 export DJANGO_LOG_DIRECTORY='/home/ec2-user/log/'
 export DEPLOYMENT_LOCATION='/home/ec2-user/State-TalentMAP-API-dev/'
 export FSBID_API_URL='https://mockfsbid.metaphasedev.com'
+export FSBID_API_URL='https://mockfsbid.metaphasedev.com/Employees'
 
 # install dependencies
 pip install -r requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     depends_on:
       - db
       - mock_fsbid
+    # use this to run in https server locally
+    # command: python manage.py runsslserver --certificate /app/talentmap_api/sp.crt --key /app/talentmap_api/sp.key 0.0.0.0:8000
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
       - .:/app

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ click==6.7
 coreapi==2.3.3
 coreschema==0.0.4
 coverage==4.5.1
-cryptography==2.2.2
+cryptography==2.1.4
 dateutils==0.6.6
 decorator==4.2.1
 defusedxml==0.5.0
@@ -23,6 +23,7 @@ django-extensions==2.0.6
 django-filter==1.1.0
 django-rest-swagger==2.1.2
 django-simple-history==2.0
+django-sslserver==0.21
 djangorestframework==3.8.2
 djangorestframework-csv==2.1.0
 djangorestframework-expiring-authtoken==0.1.4
@@ -58,7 +59,7 @@ pycryptodomex==3.6.0
 pyflakes==1.6.0
 PyJWT==1.7.1
 pyOpenSSL==17.5.0
-pysaml2==4.5.0
+pysaml2==4.4.0
 pytest==3.5.0
 pytest-cov==2.5.1
 pytest-django==3.1.2

--- a/talentmap_api/fsbid/filters.py
+++ b/talentmap_api/fsbid/filters.py
@@ -58,9 +58,7 @@ class AvailablePositionsFilter():
 
     # Used when saving a search to determine the number of records returned
     def get_count(query, jwt_token):
-        { count: 0 }
-        # TODO - once using available_positions, re-enable this and close TM-1314
-        #return ap_services.get_available_positions_count(query, jwt_token)
+        return ap_services.get_available_positions_count(query, jwt_token)
 
     class Meta:
         fields = "__all__"

--- a/talentmap_api/fsbid/services/cdo.py
+++ b/talentmap_api/fsbid/services/cdo.py
@@ -1,0 +1,27 @@
+import requests
+import logging
+import jwt
+import talentmap_api.fsbid.services.common as services
+from django.conf import settings
+
+API_ROOT = settings.FSBID_API_URL
+
+logger = logging.getLogger(__name__)
+
+def cdo(jwt_token):
+    '''
+    Get All CDOs
+    '''
+    ad_id = jwt.decode(jwt_token, verify=False).get('unique_name')
+    email = jwt.decode(jwt_token, verify=False).get('email')
+    uri = f"Agents?ad_id={ad_id}&rl_cd=CDO"
+    response = services.get_fsbid_results(uri, jwt_token, fsbid_cdo_list_to_talentmap_cdo_list, email)
+    return response
+
+def fsbid_cdo_list_to_talentmap_cdo_list(data):
+    return {
+        "id": data.get("hru_id", None),
+        "name": data.get("fullname", None),
+        "email": data.get("email", None),
+        "isCurrentUser": data.get("isCurrentUser", None),
+    }

--- a/talentmap_api/fsbid/services/client.py
+++ b/talentmap_api/fsbid/services/client.py
@@ -1,0 +1,139 @@
+import requests
+import logging
+import jwt
+import talentmap_api.fsbid.services.common as services
+import csv
+from datetime import datetime
+from django.conf import settings
+from urllib.parse import urlencode, quote
+from django.http import HttpResponse
+from django.utils.encoding import smart_str
+
+API_ROOT = settings.FSBID_API_URL
+
+logger = logging.getLogger(__name__)
+
+def client(jwt_token, hru_id, rl_cd):
+    '''
+    Get Clients by CDO
+    '''
+    ad_id = jwt.decode(jwt_token, verify=False).get('unique_name')
+    uri = f"Clients?request_params.ad_id={ad_id}"
+    if hru_id:
+        uri = uri + f'&request_params.hru_id={hru_id}'
+    if rl_cd:
+        uri = uri + f'&request_params.rl_cd={rl_cd}'
+    response = services.get_fsbid_results(uri, jwt_token, fsbid_clients_to_talentmap_clients)
+    return response
+
+def single_client(jwt_token, perdet_seq_num):
+    '''
+    Get a single client for a CDO
+    '''
+    ad_id = jwt.decode(jwt_token, verify=False).get('unique_name')
+    uri = f"Clients?request_params.ad_id={ad_id}&request_params.perdet_seq_num={perdet_seq_num}"
+    response = services.get_fsbid_results(uri, jwt_token, fsbid_clients_to_talentmap_clients)
+    return list(response)[0]
+
+def get_client_csv(query, jwt_token, rl_cd, host=None):
+    ad_id = jwt.decode(jwt_token, verify=False).get('unique_name')
+    data = services.send_get_csv_request(
+        "Clients",
+        query,
+        convert_client_query,
+        jwt_token,
+        fsbid_clients_to_talentmap_clients_for_csv,
+        "/api/v1/fsbid/client/",
+        host,
+        ad_id
+    )
+
+    response = HttpResponse(content_type='text/csv')
+    response['Content-Disposition'] = f"attachment; filename=clients_{datetime.now().strftime('%Y_%m_%d_%H%M%S')}.csv"
+
+    writer = csv.writer(response, csv.excel)
+    response.write(u'\ufeff'.encode('utf8'))
+
+    # write the headers
+    writer.writerow([
+        smart_str(u"Name"),
+        smart_str(u"Perdet Seq Number"),
+        smart_str(u"Skill"),
+        smart_str(u"Grade"),
+        smart_str(u"Employee ID"),
+        # smart_str(u"Role Code"), Might not be useful to users
+        smart_str(u"Position Location Code"),
+    ])
+
+    for record in data:
+        writer.writerow([
+            smart_str(record["name"]),
+            smart_str("=\"%s\"" % record["perdet_seq_number"]),
+            smart_str(record["skills"]),
+            smart_str("=\"%s\"" % record["grade"]),
+            smart_str("=\"%s\"" % record["employee_id"]),
+            # smart_str(record["role_code"]), Might not be useful to users
+            smart_str("=\"%s\"" % record["pos_location_code"]),
+        ])
+    return response
+
+
+def fsbid_clients_to_talentmap_clients(data):
+    return {
+        "id": data.get("perdet_seq_num", None),
+        "name": data.get("per_full_name", None),
+        "perdet_seq_number": data.get("perdet_seq_num", None),
+        "grade": data.get("grade_code", None),
+        "skills": map_skill_codes(data),
+        "employee_id": data.get("emplid", None),
+        "role_code": data.get("role_code", None),
+        "pos_location_code": data.get("pos_location_code", None),
+    }
+
+def fsbid_clients_to_talentmap_clients_for_csv(data):
+    return {
+        "id": data.get("perdet_seq_num", None),
+        "name": data.get("per_full_name", None),
+        "perdet_seq_number": data.get("perdet_seq_num", None),
+        "grade": data.get("grade_code", None),
+        "skills": '\n'.join(map_skill_codes_for_csv(data)),
+        "employee_id": data.get("emplid", None),
+        "role_code": data.get("role_code", None),
+        "pos_location_code": data.get("pos_location_code", None),
+    }
+
+def convert_client_query(query):
+    '''
+    Converts TalentMap filters into FSBid filters
+
+    The TalentMap filters align with the client search filter naming
+    '''
+    values = {
+        "request_params.hru_id": query.get("hru_id", None),
+        "request_params.rl_cd": query.get("rl_cd", None),
+        "request_params.ad_id": query.get("ad_id", None),
+        "request_params.order_by": services.sorting_values(query.get("ordering", None)),
+        "request_params.freeText": query.get("q", None),
+    }
+    return urlencode({i: j for i, j in values.items() if j is not None}, doseq=True, quote_via=quote)
+
+def map_skill_codes_for_csv(data):
+    skills = []
+    for i in range(1,4):
+        index = i
+        if i == 1:
+            index = ''
+        desc = data.get(f'skill{index}_code_desc', None)
+        skills.append(desc)
+    return filter(lambda x: x is not None, skills)
+
+def map_skill_codes(data):
+    skills = []
+    for i in range(1,4):
+        index = i
+        if i == 1:
+            index = ''
+        code = data.get(f'skill{index}_code', None)
+        desc = data.get(f'skill{index}_code_desc', None)
+        skills.append({ 'code': code, 'description': desc })
+    return filter(lambda x: x.get('code', None) is not None, skills)

--- a/talentmap_api/fsbid/services/common.py
+++ b/talentmap_api/fsbid/services/common.py
@@ -11,6 +11,7 @@ from django.conf import settings
 from django.db.models import Q
 
 from talentmap_api.organization.models import Post, Organization, OrganizationGroup
+from talentmap_api.settings import OBC_URL
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +61,19 @@ def parseLanguage(lang):
             language["representation"] = f"{match.group(1)} {match.group(2)} {match.group(3)}/{match.group(4)}"
             return language
 
+def parseLanguagesString(lang):
+    '''
+    Parses a language dictionary and turns it into a comma seperated string of languages
+    '''
+    if lang:
+        lang_str = ""
+        for l in lang:
+            if not lang_str:
+                lang_str = l["language"]
+            else:
+                lang_str += ", " + l["language"]
+
+        return lang_str
 
 def post_values(query):
     '''
@@ -138,14 +152,19 @@ def get_results(uri, query, query_mapping_function, jwt_token, mapping_function)
 
     return list(map(mapping_function, response.get("Data", {})))
 
-def get_fsbid_results(uri, jwt_token, mapping_function):
+def get_fsbid_results(uri, jwt_token, mapping_function, email=None):
     url = f"{API_ROOT}/{uri}"
     response = requests.get(url, headers={'JWTAuthorization': jwt_token, 'Content-Type': 'application/json'}, verify=False).json() # nosec
-    
+
     if response.get("Data") is None or response.get('return_code', -1) == -1:
         logger.error(f"Fsbid call to '{url}' failed.")
         return None
- 
+
+    # determine if the result is the current user
+    if email:
+        for a in response.get("Data"):
+            a['isCurrentUser'] = True if a['email'] == email else False
+
     return map(mapping_function, response.get("Data", {}))
 
 
@@ -174,12 +193,39 @@ def send_count_request(uri, query, query_mapping_function, jwt_token, host=None)
     response = requests.get(url, headers={'JWTAuthorization': jwt_token, 'Content-Type': 'application/json'}, verify=False).json()  # nosec
     return {"count": response["Data"][0]["count(1)"]}
 
+def get_obc_id(post_id):
 
-def send_get_csv_request(uri, query, query_mapping_function, jwt_token, mapping_function, base_url, host=None):
+    post = Post.objects.filter(_location_code=post_id)
+    if post.count() == 1:
+        for p in post:
+            return p.obc_id
+
+    return None
+
+def get_post_overview_url(post_id):
+    obc_id = get_obc_id(post_id)
+    if obc_id:
+        return f"{OBC_URL}/post/detail/{obc_id}"
+    else:
+        return None
+
+def get_post_bidding_considerations_url(post_id):
+    obc_id = get_obc_id(post_id)
+    if obc_id:
+        return f"{OBC_URL}/post/postdatadetails/{obc_id}"
+    else:
+        return None
+
+def send_get_csv_request(uri, query, query_mapping_function, jwt_token, mapping_function, base_url, host=None, ad_id=None):
     '''
     Gets items from FSBid
     '''
-    url = f"{API_ROOT}/{uri}?{query_mapping_function(query)}"
+    formattedQuery = query
+    formattedQuery._mutable = True
+    if (ad_id != None):
+        formattedQuery['ad_id'] = ad_id
+    logger.info(query_mapping_function(formattedQuery))
+    url = f"{API_ROOT}/{uri}?{query_mapping_function(formattedQuery)}"
     response = requests.get(url, headers={'JWTAuthorization': jwt_token, 'Content-Type': 'application/json'}, verify=False).json()  # nosec
 
     if response.get("Data") is None or response.get('return_code', -1) == -1:

--- a/talentmap_api/fsbid/services/employee.py
+++ b/talentmap_api/fsbid/services/employee.py
@@ -5,7 +5,7 @@ import jwt
 from django.conf import settings
 from django.contrib.auth.models import Group
 
-API_ROOT = settings.FSBID_API_URL
+API_ROOT = settings.EMPLOYEES_API_URL
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +14,7 @@ def get_employee_perdet_seq_num(jwt_token):
     Gets the perdet_seq_num for the employee from FSBid
     '''
     ad_id = jwt.decode(jwt_token, verify=False).get('unique_name')
-    url = f"{API_ROOT}/Employees/userInfo?ad_id={ad_id}"
+    url = f"{API_ROOT}/userInfo?ad_id={ad_id}"
     employee = requests.get(url, headers={'JWTAuthorization': jwt_token, 'Content-Type': 'application/json'}, verify=False).json()  # nosec
     return next(iter(employee.get('Data', [])), {}).get('perdet_seq_num')
 

--- a/talentmap_api/fsbid/services/projected_vacancies.py
+++ b/talentmap_api/fsbid/services/projected_vacancies.py
@@ -1,10 +1,15 @@
 import requests
 import logging
+import csv
+from datetime import datetime
+import maya
 
 from urllib.parse import urlencode, quote
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
+from django.http import HttpResponse
+from django.utils.encoding import smart_str
 
 from talentmap_api.common.common_helpers import ensure_date, safe_navigation
 import talentmap_api.fsbid.services.common as services
@@ -36,14 +41,67 @@ def get_projected_vacancies(query, jwt_token, host=None):
         host
     )
 
-
 def get_projected_vacancies_count(query, jwt_token, host=None):
     '''
     Gets the total number of PVs for a filterset
     '''
     return services.send_count_request("futureVacanciesCount", query, convert_pv_query, jwt_token, host)
 
+def get_projected_vacancies_csv(query, jwt_token, host=None):
+    data = services.send_get_csv_request(
+        "futureVacancies",
+        query,
+        convert_pv_query,
+        jwt_token,
+        fsbid_pv_to_talentmap_pv,
+        "/api/v1/fsbid/projected_vacancies/",
+        host
+    )
+    
+    response = HttpResponse(content_type='text/csv')
+    response['Content-Disposition'] = f"attachment; filename=projected_vacancies_{datetime.now().strftime('%Y_%m_%d_%H%M%S')}.csv"
 
+    writer = csv.writer(response, csv.excel)
+    response.write(u'\ufeff'.encode('utf8'))
+    
+    # write the headers
+    writer.writerow([
+        smart_str(u"Position"),
+        smart_str(u"Position Number"),
+        smart_str(u"Skill"),
+        smart_str(u"Grade"),
+        smart_str(u"Bureau"),
+        smart_str(u"Post City"),
+        smart_str(u"Post Country"),
+        smart_str(u"Tour of Duty"),
+        smart_str(u"Languages"),
+        smart_str(u"Post Differential"),
+        smart_str(u"Danger Pay"),
+        smart_str(u"TED"),
+        smart_str(u"Incumbent"),
+        smart_str(u"Bid Cycle/Season"),
+        smart_str(u"Capsule Description"),
+    ])
+   
+    for record in data:
+        writer.writerow([
+            smart_str(record["position"]["title"]),
+            smart_str("=\"%s\"" % record["position"]["position_number"]),
+            smart_str(record["position"]["skill"]),
+            smart_str("=\"%s\"" % record["position"]["grade"]),
+            smart_str(record["position"]["bureau"]),
+            smart_str(record["position"]["post"]["location"]["city"]),
+            smart_str(record["position"]["post"]["location"]["country"]),
+            smart_str(record["position"]["tour_of_duty"]),
+            smart_str(services.parseLanguagesString(record["position"]["languages"])),
+            smart_str(record["position"]["post"]["differential_rate"]),
+            smart_str(record["position"]["post"]["danger_pay"]),
+            smart_str(maya.parse(record["ted"]).datetime().strftime('%m/%d/%Y')),
+            smart_str(record["position"]["current_assignment"]["user"]),
+            smart_str(record["bidcycle"]["name"]),
+            smart_str(record["position"]["description"]["content"]),
+        ])
+    return response
 
 def fsbid_pv_to_talentmap_pv(pv):
     '''
@@ -65,7 +123,7 @@ def fsbid_pv_to_talentmap_pv(pv):
             "skill": f"{pv.get('pos_skill_desc', None)} ({pv.get('pos_skill_code')})",
             "bureau": f"({pv.get('pos_bureau_short_desc', None)}) {pv.get('pos_bureau_long_desc', None)}",
             "skill": f"{pv.get('pos_skill_desc', None)} ({pv.get('pos_skill_code')})",
-            "organization": pv.get("post_org_country_state", None),
+            "organization": f"({pv.get('org_short_desc', None)}) {pv.get('org_long_desc', None)}",
             "tour_of_duty": pv.get("tod", None),
             "languages": list(filter(None, [
                 services.parseLanguage(pv.get("lang1", None)),
@@ -73,6 +131,9 @@ def fsbid_pv_to_talentmap_pv(pv):
             ])),
             "post": {
                 "tour_of_duty": pv.get("tod", None),
+                "post_overview_url": services.get_post_overview_url(pv.get("pos_location_code", None)),
+                "post_bidding_considerations_url": services.get_post_bidding_considerations_url(pv.get("pos_location_code", None)),
+                "obc_id": services.get_obc_id(pv.get("pos_location_code", None)),
                 "differential_rate": pv.get("bt_differential_rate_num", None),
                 "danger_pay": pv.get("bt_danger_pay_num", None),
                 "location": {

--- a/talentmap_api/fsbid/tests/test_fsbid_bidlist.py
+++ b/talentmap_api/fsbid/tests/test_fsbid_bidlist.py
@@ -42,7 +42,7 @@ def test_bidder_fixture(authorized_user):
 def test_bidlist_actions(authorized_client, authorized_user):
     with patch('talentmap_api.fsbid.services.bid.requests.get') as mock_get:
         mock_get.return_value = Mock(ok=True)
-        mock_get.return_value.json.return_value = [bid]
+        mock_get.return_value.json.return_value = { 'Data': [bid] }
         response = authorized_client.get(f'/api/v1/fsbid/bidlist/', HTTP_JWT=fake_jwt)
         assert response.json()['results'][0]['emp_id'] == [bid][0]['perdet_seq_num']
 
@@ -53,12 +53,12 @@ def test_bidlist_position_actions(authorized_client, authorized_user):
     with patch('talentmap_api.fsbid.services.bid.requests.get') as mock_get:
         # returns 404 when no position is found
         mock_get.return_value = Mock(ok=True)
-        mock_get.return_value.json.return_value = []
+        mock_get.return_value.json.return_value = { 'Data': [] }
         response = authorized_client.get(f'/api/v1/fsbid/bidlist/position/1/', HTTP_JWT=fake_jwt)
         assert response.status_code == status.HTTP_404_NOT_FOUND
         # returns 204 when position is found
         mock_get.return_value = Mock(ok=True)
-        mock_get.return_value.json.return_value = [bid]
+        mock_get.return_value.json.return_value = { 'Data': [bid] }
         response = authorized_client.get(f'/api/v1/fsbid/bidlist/position/1/', HTTP_JWT=fake_jwt)
         assert response.status_code == status.HTTP_204_NO_CONTENT
 

--- a/talentmap_api/fsbid/urls/cdo.py
+++ b/talentmap_api/fsbid/urls/cdo.py
@@ -1,0 +1,15 @@
+from django.conf.urls import url
+from rest_framework import routers
+
+from talentmap_api.fsbid.views import cdo as views
+
+router = routers.SimpleRouter()
+
+urlpatterns = [
+    url(r'^position/(?P<pk>[0-9]+)/client/(?P<client_id>[0-9]+)/$', views.FSBidListPositionActionView.as_view(), name='cdo-bidding.FSBid-position-actions'),
+    url(r'^position/(?P<pk>[0-9]+)/client/(?P<client_id>[0-9]+)/submit/$', views.FSBidListBidActionView.as_view(), name='cdo-bidding.FSBid-bid-actions'),
+    url(r'^client/(?P<client_id>[0-9]+)/$', views.FSBidListView.as_view(), name="cdo-bidding-FSBid-bid-actions"),
+    url(r'^$', views.FSBidCDOListView.as_view(), name='FSBid-cdo_list'),
+]
+
+urlpatterns += router.urls

--- a/talentmap_api/fsbid/urls/client.py
+++ b/talentmap_api/fsbid/urls/client.py
@@ -1,0 +1,14 @@
+from django.conf.urls import url
+from rest_framework import routers
+
+from talentmap_api.fsbid.views import client as views
+
+router = routers.SimpleRouter()
+
+urlpatterns = [
+    url(r'^export/$', views.FSBidClientCSVView.as_view(), name="FSBid-client_export"),
+    url(r'^(?P<pk>[0-9]+)/$', views.FSBidClientView.as_view(), name='FSBid-client'),
+    url(r'^$', views.FSBidClientListView.as_view(), name='FSBid-client_list'),
+]
+
+urlpatterns += router.urls

--- a/talentmap_api/fsbid/urls/projected_vacancies.py
+++ b/talentmap_api/fsbid/urls/projected_vacancies.py
@@ -6,9 +6,9 @@ from talentmap_api.fsbid.views import projected_vacancies as views
 router = routers.SimpleRouter()
 
 urlpatterns = [
+    url(r'^export/$', views.FSBidProjectedVacanciesCSVView.as_view(), name="projected-vacancies-FSBid-projected-vacancies-csv"),
     url(r'^(?P<pk>[0-9]+)/$', views.FSBidProjectedVacancyView.as_view(), name='projected-vacancies-FSBid-projected-vacancy'),
     url(r'^$', views.FSBidProjectedVacanciesListView.as_view(), name="projected-vacancies-FSBid-projected-vacancies-actions"),
-    
 ]
 
 urlpatterns += router.urls

--- a/talentmap_api/fsbid/views/cdo.py
+++ b/talentmap_api/fsbid/views/cdo.py
@@ -1,0 +1,93 @@
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+
+from talentmap_api.user_profile.models import UserProfile
+from talentmap_api.messaging.models import Notification
+from talentmap_api.common.permissions import isDjangoGroupMember
+from talentmap_api.fsbid.views.base import BaseView
+import talentmap_api.fsbid.services.bid as services
+import talentmap_api.fsbid.services.cdo as cdoServices
+
+import logging
+logger = logging.getLogger(__name__)
+
+class FSBidCDOListView(BaseView):
+
+    def get(self, request):
+        '''
+        Gets all cdos
+        '''
+        return Response(cdoServices.cdo(request.META['HTTP_JWT']))
+
+
+class FSBidListView(BaseView):
+
+    permission_classes = (IsAuthenticated, isDjangoGroupMember('cdo'),)
+
+    def get(self, request, client_id):
+        '''
+        Gets all bids for the client user
+        '''
+        return Response({ "results": services.user_bids(client_id, request.META['HTTP_JWT'])})
+
+
+class FSBidListBidActionView(APIView):
+
+    permission_classes = (IsAuthenticated, isDjangoGroupMember('cdo'),)
+
+    def put(self, request, pk, client_id):
+        '''
+        Submits a bid (sets status to A)
+        '''
+        try:
+            services.submit_bid_on_position(client_id, pk, request.META['HTTP_JWT'])
+            user = UserProfile.objects.get(user=self.request.user)
+            Notification.objects.create(owner=UserProfile.objects.get(emp_id=client_id),
+                                        tags=['bidding'],
+                                        message=f"Bid on position id={pk} has been submitted by CDO {user}")
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        except Exception as e:
+            return Response(status=status.HTTP_422_UNPROCESSABLE_ENTITY, data=e)
+
+
+class FSBidListPositionActionView(BaseView):
+    '''
+    list:
+    Lists all bids for the clients's current bidlist
+    '''
+    permission_classes = (IsAuthenticated, isDjangoGroupMember('cdo'),)
+
+    def get(self, request, pk, client_id, format=None):
+        '''
+        Indicates if the position is in the client's bidlist
+
+        Returns 204 if the position is in the list, otherwise, 404
+        '''
+        if len(services.user_bids(client_id, request.META['HTTP_JWT'], pk)) > 0:
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        else:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+    def put(self, request, pk, client_id, format=None):
+        '''
+        Adds a cycle position to the client's bid list
+        '''
+        services.bid_on_position(client_id, pk, request.META['HTTP_JWT'])
+        user = UserProfile.objects.get(user=self.request.user)
+        Notification.objects.create(owner=UserProfile.objects.get(emp_id=client_id),
+                                        tags=['bidding'],
+                                        message=f"Bid on position id={pk} has been added to your bid list by CDO {user}")
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    def delete(self, request, pk, client_id, format=None):
+        '''
+        Closes or deletes specified bid on a cycle position
+        '''
+        services.remove_bid(client_id, pk, request.META['HTTP_JWT'])
+        user = UserProfile.objects.get(user=self.request.user)
+        Notification.objects.create(owner=UserProfile.objects.get(emp_id=client_id),
+                                        tags=['bidding'],
+                                        message=f"Bid on position id={pk} has been removed from your bid list by CDO {user}")
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/talentmap_api/fsbid/views/client.py
+++ b/talentmap_api/fsbid/views/client.py
@@ -1,0 +1,52 @@
+import coreapi
+
+from talentmap_api.fsbid.views.base import BaseView
+import talentmap_api.fsbid.services.client as services
+import talentmap_api.fsbid.services.common as common
+
+from rest_framework.response import Response
+from rest_framework.schemas import AutoSchema
+
+from talentmap_api.fsbid.views.base import BaseView
+from talentmap_api.common.permissions import isDjangoGroupMember
+from rest_framework.permissions import IsAuthenticated
+
+import talentmap_api.fsbid.services.client as services
+
+
+class FSBidClientListView(BaseView):
+    schema = AutoSchema(
+        manual_fields=[
+            coreapi.Field("hru_id", location='query', description='HRU id of the Agent'),
+            coreapi.Field("rl_cd", location='query', description='Role code of the Agent')
+        ]
+    )
+    def get(self, request):
+        '''
+        Gets all clients for a CDO
+        '''
+        return Response(services.client(request.META['HTTP_JWT'], request.query_params.get('hru_id'), request.query_params.get('rl_cd')))
+
+
+class FSBidClientView(BaseView):
+
+    def get(self, request, pk):
+        '''
+        Gets a single client by perdet_seq_num
+        '''
+        return Response(services.single_client(request.META['HTTP_JWT'], pk))
+
+class FSBidClientCSVView(BaseView):
+
+    schema = AutoSchema(
+        manual_fields=[
+            coreapi.Field("hru_id", location='query', description='HRU id of the Agent'),
+            coreapi.Field("rl_cd", location='query', description='Role code of the Agent')
+        ]
+    )
+
+    def get(self, request, *args, **kwargs):
+        '''
+        Exports all clients to CSV
+        '''
+        return services.get_client_csv(request.query_params, request.META['HTTP_JWT'], f"{request.scheme}://{request.get_host()}")

--- a/talentmap_api/fsbid/views/projected_vacancies.py
+++ b/talentmap_api/fsbid/views/projected_vacancies.py
@@ -62,3 +62,12 @@ class FSBidProjectedVacancyView(BaseView):
             return Response(status=status.HTTP_404_NOT_FOUND)
  
         return Response(result)
+
+class FSBidProjectedVacanciesCSVView(BaseView):
+
+    permission_classes = (IsAuthenticatedOrReadOnly,)
+    filter_class = ProjectedVacancyFilter
+
+    def get(self, request, *args, **kwargs):
+        
+        return services.get_projected_vacancies_csv(request.query_params, request.META['HTTP_JWT'], f"{request.scheme}://{request.get_host()}")

--- a/talentmap_api/settings.py
+++ b/talentmap_api/settings.py
@@ -105,6 +105,7 @@ INSTALLED_APPS = [
     'debug_toolbar',
     'djangosaml2',
     'simple_history',
+    "sslserver",
 
     # TalentMap Apps
     'talentmap_api.common',
@@ -474,6 +475,7 @@ STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'talentmap_api/static/')
 
 FSBID_API_URL = get_delineated_environment_variable('FSBID_API_URL', 'http://mock_fsbid:3333')
+EMPLOYEES_API_URL = get_delineated_environment_variable('EMPLOYEES_API_URL', 'http://mock_fsbid:3333/Employees')
 
 # remove actual values before committing
 AD_ID = 'DOMAIN\\USERNAME'

--- a/talentmap_api/urls.py
+++ b/talentmap_api/urls.py
@@ -47,6 +47,8 @@ urlpatterns = [
     url(r'^api/v1/fsbid/bid_seasons/', include('talentmap_api.fsbid.urls.bid_seasons')),
     url(r'^api/v1/fsbid/employee/', include('talentmap_api.fsbid.urls.employee')),
     url(r'^api/v1/fsbid/reference/', include('talentmap_api.fsbid.urls.reference')),
+    url(r'^api/v1/fsbid/cdo/', include('talentmap_api.fsbid.urls.cdo')),
+    url(r'^api/v1/fsbid/client/', include('talentmap_api.fsbid.urls.client')),
 
     # Projected Vacancies
     url(r'^api/v1/projected_vacancy/', include('talentmap_api.projected_vacancies.urls.projected_vacancies')),

--- a/talentmap_api/user_profile/models.py
+++ b/talentmap_api/user_profile/models.py
@@ -129,7 +129,7 @@ class SavedSearch(models.Model):
         filter_class = resolve_path_to_view(self.endpoint).filter_class
         query_params = format_filter(self.filters)
         if getattr(filter_class, "use_api", False):
-            count = filter_class.get_count(query_params, jwt_token)['count']
+            count = int(filter_class.get_count(query_params, jwt_token).get('count', 0))
         else:
             count = self.get_queryset().count()
 


### PR DESCRIPTION
* fix: allow for location code to be passed to post available position filter. this happens when searching for similar positions

* fix: sort bureau on the short description

* refactor to add error checking

* test file changes

* correctly updating test files this time

* fix: allow sorting on posted_date

* update to have none as default

* codes

* chore: use a docker image rather than require the mock code to be checked out (#150)

* chore: use a docker image rather than require the mock code to be checked out

* fix: move back to mock_fsbid url so containers can still talk to each other;

* feature: allow mock-fsbid to be run from local code if needed

* chore: improve the performance of the string_rep job by forcing update and limiting the fields being updated (#169)

* available positions file switch to none

* First attempt at zipping pip dependencies

* docker step

* Temporarily new steps move to build process for testing

* Testing the branch filter

* Remove branch filter for testing

* Test for only branch

* Fix only branch filter

* Run on all branches (for now)

* update naming: site -> dependencies

* log the errors

* Try to pull down hidden files (#212)

* fix: add the ad_id param to the bidding endpoint queries to send it to the server to support CDO bidding

* add location information

* Add verify=false to available positions export endpoint

* fix: cast the count var to an int

* chore: use a docker image rather than require the mock code to be checked out

* fix: move back to mock_fsbid url so containers can still talk to each other;

* feature: allow mock-fsbid to be run from local code if needed

* Add #nosec for bandit

* chore: setup docker for new mock-fsbid

* feature: get the role from the jwt and assign talentmap role

* fix: fix config for the mock

* fix: add skill number to skill value

* fix: add the capsule description update date to the responses

* TM-1380 fix bureaus

* chore: add debug env value

* fix: use new broken down location field

* fix: add skill code to the pv payload

* chore: use a correct volumne for mock db

* TM 1339 Add short description to the long description

* feature: add endpoint for getting location data from fsbid

* feature: download and properly stream zipped files to the log download

* fix: add the correct bureau information to the pv and ap response

* fix: ensure the is_cdo function works with new cdo role

* fix: allow the url to accept the extension of the file

* fix: fix the cycle filter

* fix: use country from api

* fix: comma

* TM-1293 add cones endpoint

* add a modification function to the base class

* fix: format the bidlist data

* update naming

* fix: make the skill code endpoint call the renamed fsbid endpoint

* Include capsule description in export

* update the cones endpoint

* whoops, included things I was testing

* darn testing changes

* Use correct prop names for mapping locations

* Datetime parsing with the maya library. Needed for questionable date formats

* Update test with new location data

* dev -> staging (#236) (#241)

* remove unneeded f

* fix: return 404 when no pv/ap with id is found

* cleaning up lint issues

* fix: ensure date now returns None rather than raising Exception

* fix: fix the sorting on projected vacancies. TM-1275

* Trigger notification

* Trigger notification

* fix: add location mapping to the projected vacancy. TM-1274

* fix: add verify=False to requests to fsbid

* Revert "fix: add verify=False to requests to fsbid"

This reverts commit aaa689bbdde948e817e21aeb49cc91028a69073c.

* fix: add the verify=false to the fsbid requests

* chore: nosec on verify=False lines

* add api endpoint for updating savedsearch counts

* fix: remove the assignment model and all things associated

* update endpoint

* fix: add to user profile route

* fix: handle multiple favorites

* fix: return all position designations

* safe navigation to the location of the projected vacancy

* fixing bad merge and updating export format

* fix: only return the favorite ids for the profile to shrink the payload

* feature: sort bid season on description

* chore: cleanups for sync things (#189)

* fix: fix the bureau filter on PV

* chore: remove oracle realted files

* fix: use no langage code from fsbid for checking for no language

* only update counts for user

* feature: capture ids as a filter used in comparision

* lint issues

* retrieve reference data from fsbid

* Add middleware to expose Content-Disposition header

* fix: add the about page editor group to the allowed permissions

* update filename and languages

* add remaining fsbid calls

* fix: add the about page editor group to the allowed permissions

* fix: add permission group for editing the about page. TM-1271

* refactor duplicate code

* fix language_code

* fix: comment out code that was breaking sync (#195)

* fix: return a value so things dont break

* feature: add endpoint to update user profile emp_id with perdet_seq_num from fsbid

* chore: revert files added unintentionally

* update dictionary retrieval to error check

* fix: cleanup bidding and fsbid mappings

* fix: add additional fields

* chore:minor refactoring on the similar positions logic

* fix: fix the cycle filters for available positions

* fix: return favorites as part of the user profile payload

* Pip requirements will get cached between docker-compose builds (#200)

* fix: allow for location code to be passed to post available position filter. this happens when searching for similar positions

* fix: sort bureau on the short description

* refactor to add error checking

* test file changes

* correctly updating test files this time

* fix: allow sorting on posted_date

* update to have none as default

* codes

* chore: use a docker image rather than require the mock code to be checked out (#150)

* chore: use a docker image rather than require the mock code to be checked out

* fix: move back to mock_fsbid url so containers can still talk to each other;

* feature: allow mock-fsbid to be run from local code if needed

* chore: improve the performance of the string_rep job by forcing update and limiting the fields being updated (#169)

* available positions file switch to none

* First attempt at zipping pip dependencies

* docker step

* Temporarily new steps move to build process for testing

* Testing the branch filter

* Remove branch filter for testing

* Test for only branch

* Fix only branch filter

* Run on all branches (for now)

* update naming: site -> dependencies

* log the errors

* Try to pull down hidden files (#212)

* fix: add the ad_id param to the bidding endpoint queries to send it to the server to support CDO bidding

* add location information

* Add verify=false to available positions export endpoint

* fix: cast the count var to an int

* chore: use a docker image rather than require the mock code to be checked out

* fix: move back to mock_fsbid url so containers can still talk to each other;

* feature: allow mock-fsbid to be run from local code if needed

* Add #nosec for bandit

* chore: setup docker for new mock-fsbid

* feature: get the role from the jwt and assign talentmap role

* fix: fix config for the mock

* fix: add skill number to skill value

* fix: add the capsule description update date to the responses

* TM-1380 fix bureaus

* chore: add debug env value

* fix: use new broken down location field

* fix: add skill code to the pv payload

* chore: use a correct volumne for mock db

* TM 1339 Add short description to the long description

* feature: add endpoint for getting location data from fsbid

* feature: download and properly stream zipped files to the log download

* fix: add the correct bureau information to the pv and ap response

* fix: ensure the is_cdo function works with new cdo role

* fix: allow the url to accept the extension of the file

* fix: fix the cycle filter

* fix: use country from api

* fix: comma

* TM-1293 add cones endpoint

* add a modification function to the base class

* fix: format the bidlist data

* update naming

* fix: make the skill code endpoint call the renamed fsbid endpoint

* Include capsule description in export

* get the obc ids for the dynamic apis

* remove test statement

* wrong value

* Add Data prop wrapper around bids

* add urls

* add to projected vacancies

* Wrap bid statistics in object

* Catch errors for invalid datetimes in the available csv export

* projected vacancies export

* Map cp_status == "HS" to has_handshake_offered

* Add url for clients

* Add urls for fsbid

* Add services file for client

* Add view client file

* Notes

* Match AP organization format

* Add constant for api root, note to finish this

* Update services methods for clients get_agents

* Update views for clients get_agents

* Update method to call helper function for converting response to talentmap formatting

* Remove comments

* Fix syntax

* Fix syntax errors and gitignore seed data file

* chore: fix the test

* fix: reenable saved search counts using the fsbid api

* Update services and views for get clients by CDO

* Update mapping for get clients

* Spelling error

* Refactor get_cdos

* Parse languages

* Refactor to use base view

* Refactor

* Update clients view and services

* Add route

* Update naming and endpoints to match web services

* Add refactoring for seperating agents and clients functionality

* Refactor

* Fix spelling error

* feature: cdo bidding on behalf of their client

* Use correct service

* chore: update docs for get clients

* chore: return skills as an array

* feature: add endpoint for getting single client

* Use sslserver and correct dependencies

* fix: update client endpoint param names

* fix: filter clients by hru_id and not ad_id

* fix: filter the clients by role as well

* Filter out deleted bids

* fix: map a legit value to the id field of a client data payload

* Associate the object with the user if the email values match

* Fix the requested position id being included in similar position results

* fix: add a new var for the employee api root

* Export clients to CSV

* Update conditional to determine bid status and date

* Map can delete to delete_ind 'Y'

Co-authored-by: Rob Tirserio <rtirserio@gmail.com>
Co-authored-by: BaldwinJordan <49635023+BaldwinJordan@users.noreply.github.com>
Co-authored-by: Nat Burgwyn <burgwyn@gmail.com>
Co-authored-by: Scott Burdick <38047685+scott062@users.noreply.github.com>